### PR TITLE
add ability to authenticate using AWS env vars in addition to AWS profile

### DIFF
--- a/scripts/self-signed-cert-utility/self-signed-cert-utility.py
+++ b/scripts/self-signed-cert-utility/self-signed-cert-utility.py
@@ -22,6 +22,10 @@ KEY_FILE = "key.pem"
 
 DEFAULT_APP_DOMAIN = "aoss.rag"
 
+AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID"
+AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
+AWS_SESSION_TOKEN = "AWS_SESSION_TOKEN"
+
 
 def generate_ssl_keys(key_config):
     """Generate ssl keys
@@ -180,6 +184,10 @@ def _cli_args():
                         "--verbose",
                         action="store_true",
                         help="debug log output")
+    parser.add_argument("-e",
+                        "--env",
+                        action="store_true",
+                        help="Use environment variables for AWS credentials")
     return parser.parse_args()
 
 
@@ -204,8 +212,21 @@ def main():
     # silence chatty libraries
     _silence_noisy_loggers()
 
-    LOGGER.info(f"AWS Profile being used: {args.aws_profile}")
-    boto3.setup_default_session(profile_name=args.aws_profile)
+    if args.env:
+        LOGGER.info(
+            "Attempting to fetch AWS credentials via environment variables")
+        aws_access_key_id = os.environ.get(AWS_ACCESS_KEY_ID)
+        aws_secret_access_key = os.environ.get(AWS_SECRET_ACCESS_KEY)
+        aws_session_token = os.environ.get(AWS_SESSION_TOKEN)
+        if not aws_secret_access_key or not aws_access_key_id or not aws_session_token:
+            raise Exception(
+                f"Missing one or more environment variables - " 
+                f"'{AWS_ACCESS_KEY_ID}', '{AWS_SECRET_ACCESS_KEY}', "
+                f"'{AWS_SESSION_TOKEN}'"
+            )
+    else:
+        LOGGER.info(f"AWS Profile being used: {args.aws_profile}")
+        boto3.setup_default_session(profile_name=args.aws_profile)
 
     cert_name = os.environ.get("IAM_SELF_SIGNED_SERVER_CERT_NAME")
     if not cert_name:


### PR DESCRIPTION
These two python scripts originally could only authenticate with AWS via the AWS profile. Now they can do so via environment variables as well.

Similar to a change I made in another sample - https://github.com/aws-samples/cognito-user-token-helper/commit/f9cf306b12478e28bdaec640263fc55f7cc1f9d2